### PR TITLE
10 add option for path prefix

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,11 @@
+import os
+import platform
+
+os_default_root_path_mapping = {
+    "Windows": "c://",
+    "Darwin": "/",
+    "Linux": "/",
+    "Java": "/",
+    "": "/",
+}
+ROOT_PATH = os.getenv("DFM_ROOT_PATH", os_default_root_path_mapping[platform.system()])

--- a/src/cli.py
+++ b/src/cli.py
@@ -56,7 +56,6 @@ def main():
         parameters = parse_parameter_string(args.parameters)
     else:
         parameters = None
-
     if args.action == "merge":
         cfg = BuildConfig.load_config_from_file(args.config_file_path, parameters)
         cfg.build()

--- a/src/config.py
+++ b/src/config.py
@@ -135,7 +135,10 @@ class BuildConfig:
         )
 
     @staticmethod
-    def load_config_from_file(file_path: Path, parameters=None):
+    def load_config_from_file(
+        file_path: Path,
+        parameters=None,
+    ):
         if parameters is None:
             parameters = {}
         config_dict = JsonFileType.load_from_file(file_path)

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from jsonpath_ng import parse
 
+from src import ROOT_PATH
 from src.file_location import FileLocation, Substitution
 from src.file_types import JsonFileType
 from src.json_merger import JsonMergerFactory
@@ -58,9 +59,9 @@ class DestinationFile:
             raise Exception(
                 "Attempting to use multiple destination files. We don't support this (yet)!"
             )
-        if (Path("/") / self.destination_file_location.substituted_path).exists():
+        if (Path(ROOT_PATH) / self.destination_file_location.substituted_path).exists():
             self.file_content = JsonFileType.load_from_file(
-                Path("/") / self.destination_file_location.substituted_path
+                Path(ROOT_PATH) / self.destination_file_location.substituted_path
             )
         else:
             self.file_content = {}
@@ -129,7 +130,7 @@ class BuildConfig:
         # JsonFileType.save_to_file(content, self.destination_file.destination_file_location.resolved_paths[0])
         JsonFileType.save_to_file(
             content,
-            Path("/")
+            Path(ROOT_PATH)
             / self.destination_file.destination_file_location.substituted_path,
         )
 

--- a/src/file_location.py
+++ b/src/file_location.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from src import ROOT_PATH
 from src.reference_types import BaseReferenceType
 from src.regex import RegexExtractor
 
@@ -59,9 +60,7 @@ class FileLocation:
                     then finds all local files matching this path.
         Returns:    A list of pathlib paths that satisfy the file search
         """
-        p = Path(
-            "/"
-        )  # TODO somehow set the root node to search for files from. Either an env var or in the file. Probably the file.
+        p = Path(ROOT_PATH)
         return list(p.glob(self.substituted_path))
 
     def substitute(self) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from src import ROOT_PATH
 from src.config import BuildConfig, DestinationFile, SourceFile
 from src.file_location import FileLocation, Substitution
 from src.file_types import JsonFileType
@@ -165,39 +166,52 @@ class TestConfigs:
     This causes a problem because running unit tests locally vs running them in CI/CD will need the paths to be entirely different.
     TODO Re-add this test once we complete https://github.com/ServerlessSam/data-file-merge/issues/10
     """
-    # def test_config_load(self):
-    #     parameters = {"TheWordTest": "test"}
-    #     expected_config = BuildConfig(
-    #         source_files=[
-    #             SourceFile(
-    #                 source_file_location=FileLocation(
-    #                     path= str(Path().absolute() / "tests/test_files_directory/nested_directory/nested_${Sub1}_file_1.json")[1:],
-    #                     subs={
-    #                         "Sub1": Substitution(
-    #                             ParameterReferenceType(parameters), "TheWordTest"
-    #                         )
-    #                     },
-    #                 ),
-    #                 source_file_root="$.AnotherKeyInTheFile",
-    #                 destination_file_content="$",
-    #             ),
-    #             SourceFile(
-    #                 source_file_location=FileLocation(
-    #                     path= str(Path().absolute() / "tests/test_files_directory/nested_directory/nested_${Sub1}_file_2.json")[1:],
-    #                     subs={"Sub1": Substitution(LiteralReferenceType(), "test")},
-    #                 ),
-    #                 source_file_root="$.AnotherKeyInTheFile",
-    #                 destination_file_content="$",
-    #             ),
-    #         ],
-    #         destination_file=DestinationFile(
-    #             FileLocation(
-    #                 path= str(Path().absolute() / "tests/test_files_directory/nested_directory/build_test_merged_file.json")[1:]
-    #             )
-    #         ),
-    #     )
-    #     generated_config = BuildConfig.load_config_from_file(
-    #         file_path= str(Path().absolute() / "tests/test_files_directory/nested_directory/build_test_config.json"),
-    #         parameters=parameters,
-    #     )
-    #     assert expected_config == generated_config
+
+    def test_config_load(self):
+        parameters = {"TheWordTest": "test"}
+        expected_config = BuildConfig(
+            source_files=[
+                SourceFile(
+                    source_file_location=FileLocation(
+                        path=str(
+                            Path(ROOT_PATH)
+                            / "tests/test_files_directory/nested_directory/nested_${Sub1}_file_1.json"
+                        )[1:],
+                        subs={
+                            "Sub1": Substitution(
+                                ParameterReferenceType(parameters), "TheWordTest"
+                            )
+                        },
+                    ),
+                    source_file_root="$.AnotherKeyInTheFile",
+                    destination_file_content="$",
+                ),
+                SourceFile(
+                    source_file_location=FileLocation(
+                        path=str(
+                            Path(ROOT_PATH)
+                            / "tests/test_files_directory/nested_directory/nested_${Sub1}_file_2.json"
+                        )[1:],
+                        subs={"Sub1": Substitution(LiteralReferenceType(), "test")},
+                    ),
+                    source_file_root="$.AnotherKeyInTheFile",
+                    destination_file_content="$",
+                ),
+            ],
+            destination_file=DestinationFile(
+                FileLocation(
+                    path=str(
+                        Path(ROOT_PATH)
+                        / "tests/test_files_directory/nested_directory/build_test_merged_file.json"
+                    )[1:]
+                )
+            ),
+        )
+        generated_config = BuildConfig.load_config_from_file(
+            file_path=str(
+                Path().absolute()
+                / "tests/test_files_directory/nested_directory/build_test_config.json"
+            ),
+            parameters=parameters,
+        )
+        assert expected_config == generated_config

--- a/tests/test_files_directory/nested_directory/build_test_config.json
+++ b/tests/test_files_directory/nested_directory/build_test_config.json
@@ -2,7 +2,7 @@
     "SourceFiles" : [
         {
             "SourceFileLocation" : {
-                "Path" : "<REPLACE WITH PATH TO REPO>/tests/test_files_directory/nested_directory/nested_${Sub1}_file_1.json",
+                "Path" : "tests/test_files_directory/nested_directory/nested_${Sub1}_file_1.json",
                 "PathSubs" : {
                     "Sub1" : {
                         "Type" : "Parameter",
@@ -15,7 +15,7 @@
         },
         {
             "SourceFileLocation" : {
-                "Path" : "<REPLACE WITH PATH TO REPO>/tests/test_files_directory/nested_directory/nested_${Sub1}_file_2.json",
+                "Path" : "tests/test_files_directory/nested_directory/nested_${Sub1}_file_2.json",
                 "PathSubs" : {
                     "Sub1" : {
                         "Type" : "Literal",
@@ -29,7 +29,7 @@
     ],
     "DestinationFile" : {
         "DestinationFileLocation" : {
-            "Path" : "<REPLACE WITH PATH TO REPO>/tests/test_files_directory/nested_directory/build_test_merged_file.json",
+            "Path" : "tests/test_files_directory/nested_directory/build_test_merged_file.json",
             "PathSubs" : {}
         }
     }


### PR DESCRIPTION
`DFM_ROOT_PATH` env var added and read into the code correctly.
Tests updated that read from physical config files
Also tested on the dfm-examples repo