### PR TITLE
18 ensure generated cli for releases is simply called dfm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && 7z a ./cli-windows.zip ./dist/dfm
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && 7z a ./cli-windows.zip ./dist/dfm.exe
       - store_artifacts:
           path: cli-windows.zip
   create-cli-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && zip -r cli-windows.zip dist/dfm 
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && powershell Compress-Archive dist/dfm cli-windows.zip
       - store_artifacts:
           path: cli-windows.zip
   create-cli-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry install && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && zip -r cli-windows.zip dist/dfm 
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && zip -r cli-windows.zip dist/dfm 
       - store_artifacts:
           path: cli-windows.zip
   create-cli-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,10 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && powershell Compress-Archive ./dist/dfm ./cli-windows.zip
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm
       - store_artifacts:
-          path: cli-windows.zip
+          path: dist
+          destination: cli-windows
   create-cli-linux:
     docker:
       - image: cimg/python:3.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && powershell Compress-Archive dist/dfm cli-windows.zip
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && powershell Compress-Archive ./dist/dfm ./cli-windows.zip
       - store_artifacts:
           path: cli-windows.zip
   create-cli-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,15 +73,15 @@ workflows:
       - test
   create-cli:
     jobs:
-      - create-cli-linux
-          # filters:
-          #   branches:
-          #     only: main
-      - create-cli-windows
-          # filters:
-          #   branches:
-          #     only: main
-      - create-cli-mac
-          # filters:
-          #   branches:
-          #     only: main
+      - create-cli-linux:
+          filters:
+            branches:
+              only: main
+      - create-cli-windows:
+          filters:
+            branches:
+              only: main
+      - create-cli-mac:
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,14 @@ workflows:
   create-cli:
     jobs:
       - create-cli-linux:
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - create-cli-windows:
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - create-cli-mac:
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && 7z a ./cli-windows.zip ./dist/dfm.exe
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && 7z a ./cli-windows.zip ./dist/
       - store_artifacts:
           path: cli-windows.zip
   create-cli-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,9 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm
+            curl -sSL https://install.python-poetry.org | python - && ..\AppData\Roaming\Python\Scripts\poetry install && ..\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && 7z a ./cli-windows.zip ./dist/dfm
       - store_artifacts:
-          path: dist
-          destination: cli-windows
+          path: cli-windows.zip
   create-cli-linux:
     docker:
       - image: cimg/python:3.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,11 +32,10 @@ jobs:
           name: Build Windows CLI
           shell: cmd.exe
           command: |
-            curl -sSL https://install.python-poetry.org | python - && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry install && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm
+            curl -sSL https://install.python-poetry.org | python - && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry install && C:\Users\circleci.PACKER-631B74C9\AppData\Roaming\Python\Scripts\poetry run pyinstaller src/cli.py --onefile --name dfm && zip -r cli-windows.zip dist/dfm 
       - store_artifacts:
-          path: dist/dfm.exe
-          destination: cli-windows
-  create-cli-unix:
+          path: cli-windows.zip
+  create-cli-linux:
     docker:
       - image: cimg/python:3.10
     steps:
@@ -45,10 +44,11 @@ jobs:
          pkg-manager: poetry
       - run:
           name: Create CLI
-          command: poetry run pyinstaller src/cli.py --onefile --name dfm
+          command: |
+            poetry run pyinstaller src/cli.py --onefile --name dfm
+            zip -r cli-linux.zip dist/dfm 
       - store_artifacts:
-          path: dist/dfm
-          destination: cli-unix
+          path: cli-linux.zip
   create-cli-mac:
     macos:
       xcode: 13.4.1
@@ -62,10 +62,9 @@ jobs:
             curl -sSL https://install.python-poetry.org | python3 -
             $HOME/.local/bin/poetry install
             $HOME/.local/bin/poetry run pyinstaller src/cli.py --onefile --name dfm
+            zip -r cli-mac.zip dist/dfm 
       - store_artifacts:
-          path: dist/dfm
-          destination: cli-mac     
-
+          path: cli-mac.zip
 
 workflows:
   lint-and-test:
@@ -74,7 +73,7 @@ workflows:
       - test
   create-cli:
     jobs:
-      - create-cli-unix:
+      - create-cli-linux:
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,15 +73,15 @@ workflows:
       - test
   create-cli:
     jobs:
-      - create-cli-linux:
+      - create-cli-linux
           # filters:
           #   branches:
           #     only: main
-      - create-cli-windows:
+      - create-cli-windows
           # filters:
           #   branches:
           #     only: main
-      - create-cli-mac:
+      - create-cli-mac
           # filters:
           #   branches:
           #     only: main


### PR DESCRIPTION
Now the artifacts stored in CircleCI are the following
cli-<OS>.zip -- dist/ -- dfm(.exe)

Installation instructions should be updated too. I will move them to the readme as part of #21 