### PR TITLE
Update config names of for src and dest file to use 'node' suffix

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -164,8 +164,8 @@ class BuildConfig:
             source_files.append(
                 SourceFile(
                     FileLocation(src["SourceFileLocation"]["Path"], subs),
-                    src["SourceFileRoot"],
-                    src["DestinationFileContent"],
+                    src["SourceFileNode"],
+                    src["DestinationFileNode"],
                 )
             )
         dest_subs = {}

--- a/tests/test_files_directory/nested_directory/build_test_config.json
+++ b/tests/test_files_directory/nested_directory/build_test_config.json
@@ -10,8 +10,8 @@
                     }
                 }
             },
-            "SourceFileRoot" : "$.AnotherKeyInTheFile",
-            "DestinationFileContent" : "$"
+            "SourceFileNode" : "$.AnotherKeyInTheFile",
+            "DestinationFileNode" : "$"
         },
         {
             "SourceFileLocation" : {
@@ -23,8 +23,8 @@
                     }
                 }
             },
-            "SourceFileRoot" : "$.AnotherKeyInTheFile",
-            "DestinationFileContent" : "$"
+            "SourceFileNode" : "$.AnotherKeyInTheFile",
+            "DestinationFileNode" : "$"
         }
     ],
     "DestinationFile" : {


### PR DESCRIPTION
FYI - This is a breaking change. Currently working config files will not work with the new code.
It's a naming change to add standardisation and make it clearer what the key actually is.

Rename `SourceFileRoot` with `SourceFileNode` and `DestinationFileContent` with `DestinationFileNode` 